### PR TITLE
Remove asterisk prefixed properties as they are used for IE7 compatibility and cause esbuild to complain

### DIFF
--- a/spectrum.css
+++ b/spectrum.css
@@ -10,8 +10,6 @@ License: MIT
     top:0;
     left:0;
     display:inline-block;
-    *display: inline;
-    *zoom: 1;
     /* https://github.com/bgrins/spectrum/issues/40 */
     z-index: 9999994;
     overflow: hidden;
@@ -216,7 +214,6 @@ License: MIT
 /* Clearfix hack */
 .sp-cf:before, .sp-cf:after { content: ""; display: table; }
 .sp-cf:after { clear: both; }
-.sp-cf { *zoom: 1; }
 
 /* Mobile devices, make hue slider bigger so it is easier to slide */
 @media (max-device-width: 480px) {
@@ -368,8 +365,6 @@ See http://bgrins.github.io/spectrum/themes/ for instructions.
     cursor:pointer;
     padding: 4px;
     display:inline-block;
-    *zoom: 1;
-    *display: inline;
     border: solid 1px #91765d;
     background: #eee;
     color: #333;
@@ -402,7 +397,6 @@ See http://bgrins.github.io/spectrum/themes/ for instructions.
 }
 
 .sp-palette {
-    *width: 220px;
     max-width: 220px;
 }
 .sp-palette .sp-thumb-el {


### PR DESCRIPTION
Doing some prep work for getting esbuild out there and this package has some old internet explorer compatibility things going on in it that esbuild throws a bunch of errors out for.

I figure we aren't too concerned about supporting IE7 or below but let me know if not and we can figure something else out.